### PR TITLE
allowing admin to delete his own messages

### DIFF
--- a/chat/cqrs/event_handler_chat.go
+++ b/chat/cqrs/event_handler_chat.go
@@ -1194,7 +1194,10 @@ func (m *EventHandler) OnMessageRemoved(ctx context.Context, event *MessageDelet
 	if err != nil {
 		return err
 	}
-	if !CanDeleteMessage(event.AdditionalData.BehalfUserId, adt.MessageOwnerId, adt.ChatCanWriteMessage) {
+
+	canWriteMessage := CanWriteMessage(adt.IsParticipant, adt.IsChatAdmin, adt.ChatCanWriteMessage)
+
+	if !CanDeleteMessage(event.AdditionalData.BehalfUserId, adt.MessageOwnerId, canWriteMessage) {
 		m.lgr.InfoContext(ctx, "Skipping OnMessageRemoved because there is no authorization to do so", logger.AttributeChatId, event.ChatId, logger.AttributeUserId, event.AdditionalData.BehalfUserId)
 		return nil
 	}


### PR DESCRIPTION
changing the  adt.ChatCanWriteMessage to canWriteMessage to check first if the user allowed to write a message or if the user is admin 

make it compatible with the way the checks happen in the handle method of the MessageDelete struct 

without this in the Tet-a-tet chats neither of the users will be able to delete their own messages even though both are admins 

and in reguler chats the admin will not be able to delete his own messages if the reguler user is not allowed to write a message 