### PR TITLE
Feature/allow admin to delete any message

### DIFF
--- a/chat/config/config.go
+++ b/chat/config/config.go
@@ -157,7 +157,8 @@ type MessageConfig struct {
 }
 
 type ChatConfig struct {
-	TetATet TetATetConfig
+	TetATet                  TetATetConfig
+	AdminCanDeleteAnyMessage bool
 }
 
 type BlogConfig struct {
@@ -165,9 +166,8 @@ type BlogConfig struct {
 }
 
 type TetATetConfig struct {
-	CanResend                bool
-	CanReact                 bool
-	AdminCanDeleteAnyMessage bool
+	CanResend bool
+	CanReact  bool
 }
 
 type RabbitMQConfig struct {

--- a/chat/config/config.go
+++ b/chat/config/config.go
@@ -165,8 +165,9 @@ type BlogConfig struct {
 }
 
 type TetATetConfig struct {
-	CanResend bool
-	CanReact  bool
+	CanResend                bool
+	CanReact                 bool
+	AdminCanDeleteAnyMessage bool
 }
 
 type RabbitMQConfig struct {

--- a/chat/config/config/config-dev.yml
+++ b/chat/config/config/config-dev.yml
@@ -103,6 +103,8 @@ chat:
   tetatet:
     canResend: true
     canReact: true
+    AdminCanDeleteAnyMessage: false 
+
 
 blog:
   restrictCreateBlog: false

--- a/chat/config/config/config-test.yml
+++ b/chat/config/config/config-test.yml
@@ -101,6 +101,8 @@ chat:
   tetatet:
     canResend: true
     canReact: true
+    AdminCanDeleteAnyMessage: false 
+
 
 blog:
   restrictCreateBlog: false

--- a/chat/cqrs/command_handler.go
+++ b/chat/cqrs/command_handler.go
@@ -110,6 +110,7 @@ type ChatCreate struct {
 	RegularParticipantCanPinMessage     bool
 	RegularParticipantCanWriteMessage   bool
 	RegularParticipantCanAddParticipant bool
+	AdminCanDeleteAnyMessage            bool
 }
 
 type ChatEdit struct {
@@ -128,6 +129,7 @@ type ChatEdit struct {
 	RegularParticipantCanPinMessage     bool
 	RegularParticipantCanWriteMessage   bool
 	RegularParticipantCanAddParticipant bool
+	AdminCanDeleteAnyMessage            bool
 }
 
 func (cc *ChatEdit) IsValidatabale() bool {

--- a/chat/cqrs/command_handler.go
+++ b/chat/cqrs/command_handler.go
@@ -408,6 +408,7 @@ func (sp *ChatCreate) Handle(ctx context.Context, eventBus *KafkaProducer, dba *
 			RegularParticipantCanPinMessage:     copyCommand.RegularParticipantCanPinMessage,
 			RegularParticipantCanWriteMessage:   copyCommand.RegularParticipantCanWriteMessage,
 			RegularParticipantCanAddParticipant: copyCommand.RegularParticipantCanAddParticipant,
+			AdminCanDeleteAnyMessage:            copyCommand.AdminCanDeleteAnyMessage,
 		},
 	}
 	err = eventBus.Publish(ctx, cc)
@@ -484,6 +485,7 @@ func (sp *ChatEdit) Handle(ctx context.Context, eventBus *KafkaProducer, dba *db
 			RegularParticipantCanPinMessage:     copyCommand.RegularParticipantCanPinMessage,
 			RegularParticipantCanWriteMessage:   copyCommand.RegularParticipantCanWriteMessage,
 			RegularParticipantCanAddParticipant: copyCommand.RegularParticipantCanAddParticipant,
+			AdminCanDeleteAnyMessage:            copyCommand.AdminCanDeleteAnyMessage,
 		},
 	}
 	err = eventBus.Publish(ctx, cc)
@@ -990,7 +992,7 @@ func (s *MessageDelete) Handle(ctx context.Context, eventBus *KafkaProducer, dba
 
 	canWriteMessage := CanWriteMessage(adt.IsParticipant, adt.IsChatAdmin, adt.ChatCanWriteMessage)
 
-	if !CanDeleteMessage(s.AdditionalData.BehalfUserId, adt.MessageOwnerId, canWriteMessage) {
+	if !CanDeleteMessage(s.AdditionalData.BehalfUserId, adt.MessageOwnerId, canWriteMessage, adt.IsChatAdmin, adt.AdminCanDeleteAnyMessage) {
 		return NewUnauthorizedError(fmt.Sprintf("user %v is not authorized to delete the message in chat %v", s.AdditionalData.BehalfUserId, s.ChatId))
 	}
 

--- a/chat/cqrs/event_handler_chat.go
+++ b/chat/cqrs/event_handler_chat.go
@@ -1197,7 +1197,7 @@ func (m *EventHandler) OnMessageRemoved(ctx context.Context, event *MessageDelet
 
 	canWriteMessage := CanWriteMessage(adt.IsParticipant, adt.IsChatAdmin, adt.ChatCanWriteMessage)
 
-	if !CanDeleteMessage(event.AdditionalData.BehalfUserId, adt.MessageOwnerId, canWriteMessage) {
+	if !CanDeleteMessage(event.AdditionalData.BehalfUserId, adt.MessageOwnerId, canWriteMessage, adt.IsChatAdmin, adt.AdminCanDeleteAnyMessage) {
 		m.lgr.InfoContext(ctx, "Skipping OnMessageRemoved because there is no authorization to do so", logger.AttributeChatId, event.ChatId, logger.AttributeUserId, event.AdditionalData.BehalfUserId)
 		return nil
 	}

--- a/chat/cqrs/events.go
+++ b/chat/cqrs/events.go
@@ -95,6 +95,7 @@ type ChatCommoned struct {
 	RegularParticipantCanPinMessage     bool    `json:"regularParticipantCanPinMessage"`
 	RegularParticipantCanWriteMessage   bool    `json:"regularParticipantCanWriteMessage"`
 	RegularParticipantCanAddParticipant bool    `json:"regularParticipantCanAddParticipant"`
+	AdminCanDeleteAnyMessage            bool    `json:"adminCanDeleteAnyMessage"`
 }
 
 type ChatCreated struct {

--- a/chat/cqrs/projection_chat.go
+++ b/chat/cqrs/projection_chat.go
@@ -88,6 +88,7 @@ func (m *CommonProjection) OnChatCreated(ctx context.Context, event *ChatCreated
 			,regular_participant_can_pin_message
 			,regular_participant_can_write_message
 			,regular_participant_can_add_participant
+			,admin_can_delete_any_message
 		) values (
 			$1
 			,$2
@@ -102,6 +103,7 @@ func (m *CommonProjection) OnChatCreated(ctx context.Context, event *ChatCreated
 		    ,$11
 		    ,$12
 		    ,$13
+			,$14
 		)
 		on conflict(id) do update set 
 		    title = excluded.title
@@ -115,7 +117,7 @@ func (m *CommonProjection) OnChatCreated(ctx context.Context, event *ChatCreated
 			,regular_participant_can_pin_message = excluded.regular_participant_can_pin_message
 			,regular_participant_can_write_message = excluded.regular_participant_can_write_message
 			,regular_participant_can_add_participant = excluded.regular_participant_can_add_participant
-	`, event.ChatId, event.Title, event.AdditionalData.CreatedAt, event.TetATet, event.Avatar, event.AvatarBig, event.CanResend, event.CanReact, event.AvailableToSearch, event.RegularParticipantCanPublishMessage, event.RegularParticipantCanPinMessage, event.RegularParticipantCanWriteMessage, event.RegularParticipantCanAddParticipant)
+	`, event.ChatId, event.Title, event.AdditionalData.CreatedAt, event.TetATet, event.Avatar, event.AvatarBig, event.CanResend, event.CanReact, event.AvailableToSearch, event.RegularParticipantCanPublishMessage, event.RegularParticipantCanPinMessage, event.RegularParticipantCanWriteMessage, event.RegularParticipantCanAddParticipant, event.AdminCanDeleteAnyMessage)
 		if errInner != nil {
 			return errInner
 		}
@@ -173,8 +175,9 @@ func (m *CommonProjection) OnChatEdited(ctx context.Context, event *ChatEdited) 
 				,regular_participant_can_pin_message = $9
 				,regular_participant_can_write_message = $10
 				,regular_participant_can_add_participant = $11
+				,admin_can_delete_any_message= $12
 			where id = $1
-		`, event.ChatId, event.Title, event.Avatar, event.AvatarBig, event.CanResend, event.CanReact, event.AvailableToSearch, event.RegularParticipantCanPublishMessage, event.RegularParticipantCanPinMessage, event.RegularParticipantCanWriteMessage, event.RegularParticipantCanAddParticipant)
+		`, event.ChatId, event.Title, event.Avatar, event.AvatarBig, event.CanResend, event.CanReact, event.AvailableToSearch, event.RegularParticipantCanPublishMessage, event.RegularParticipantCanPinMessage, event.RegularParticipantCanWriteMessage, event.RegularParticipantCanAddParticipant, event.AdminCanDeleteAnyMessage)
 		if errInner != nil {
 			return errInner
 		}
@@ -985,6 +988,7 @@ func (m *CommonProjection) GetChatDataForAuthorization(ctx context.Context, co d
 			,coalesce(cc.can_react, false) as chat_can_react_on_message
 			,coalesce(cc.available_to_search, false) as chat_is_available_to_search
 			,coalesce(cc.regular_participant_can_add_participant, false) as regular_participant_can_add_participant
+			,coalesce(cc.admin_can_delete_any_message) as admin_can_delete_any_message
 			,b.id is not null as chat_is_blog
 		FROM provided pr
 		LEFT JOIN chat_info cc on pr.chat_id = cc.id
@@ -1337,7 +1341,8 @@ func (m *CommonProjection) GetChatsBasicExtended(ctx context.Context, co db.Comm
 			c.available_to_search,
 			c.regular_participant_can_publish_message,
 			c.regular_participant_can_pin_message,
-			c.regular_participant_can_write_message
+			c.regular_participant_can_write_message,
+			c.admin_can_delete_any_message
 		FROM chat_common c
 		CROSS JOIN requested_participants re
 		LEFT JOIN chats_participants cp ON (c.id = cp.chat_id and re.user_id = cp.user_id)

--- a/chat/cqrs/projection_message.go
+++ b/chat/cqrs/projection_message.go
@@ -684,17 +684,17 @@ func enrichMessage(
 		return nil, fmt.Errorf("Logical error during enriching messages not found chat by chatId = %v, userId = %v", chatId, behalfUserId)
 	}
 
-	setMessagePersonalizedFields(&me, chat.TetATet, chat.IsBlog, chat.RegularParticipantCanPublishMessage, chat.RegularParticipantCanPinMessage, chat.RegularParticipantCanWriteMessage, areAdmins[behalfUserId], behalfUserId, isParticipant, bloggingIsAllowed)
+	setMessagePersonalizedFields(&me, chat.TetATet, chat.IsBlog, chat.RegularParticipantCanPublishMessage, chat.RegularParticipantCanPinMessage, chat.RegularParticipantCanWriteMessage, areAdmins[behalfUserId], behalfUserId, isParticipant, bloggingIsAllowed, chat.AdminCanDeleteAnyMessage)
 
 	return &me, nil
 }
 
-func setMessagePersonalizedFields(copied *dto.MessageViewEnrichedDto, chatTetATet, chatIsBlog, chatRegularParticipantCanPublishMessage, chatRegularParticipantCanPinMessage, chatCanWriteMessage, chatIsAdmin bool, participantId int64, isParticipant bool, bloggingIsAllowed bool) {
+func setMessagePersonalizedFields(copied *dto.MessageViewEnrichedDto, chatTetATet, chatIsBlog, chatRegularParticipantCanPublishMessage, chatRegularParticipantCanPinMessage, chatCanWriteMessage, chatIsAdmin bool, participantId int64, isParticipant bool, bloggingIsAllowed bool, admincandeleteanymessage bool) {
 	canWriteMessage := CanWriteMessage(isParticipant, chatIsAdmin, chatCanWriteMessage)
 
 	copied.CanEdit = CanEditMessage(participantId, copied.OwnerId, copied.EmbedMessage != nil, copied.GetEmbedTypeSafe(), canWriteMessage)
 	copied.CanSyncEmbed = CanSyncEmbedMessage(participantId, copied.OwnerId, copied.EmbedMessage != nil, canWriteMessage)
-	copied.CanDelete = CanDeleteMessage(participantId, copied.OwnerId, canWriteMessage)
+	copied.CanDelete = CanDeleteMessage(participantId, copied.OwnerId, canWriteMessage, chatIsAdmin, admincandeleteanymessage)
 	copied.CanPublish = CanPublishMessage(chatRegularParticipantCanPublishMessage, chatIsAdmin, copied.OwnerId, participantId)
 	copied.CanPin = CanPinMessage(chatRegularParticipantCanPinMessage, chatIsAdmin)
 
@@ -784,6 +784,7 @@ func (m *CommonProjection) GetMessageDataForAuthorization(ctx context.Context, c
 			,coalesce(cc.regular_participant_can_pin_message, false) as chat_can_pin_message
 			,coalesce(cc.regular_participant_can_publish_message, false) as chat_can_publish_message
 			,b.id is not null as chat_is_blog
+			,coalesce(cc.admin_can_delete_any_message,false) as admin_can_delete_any_message
 		FROM provided pr
 		LEFT JOIN chat_info cc on pr.chat_id = cc.id
 		LEFT JOIN message_info mm ON pr.message_id = mm.id

--- a/chat/cqrs/projection_message.go
+++ b/chat/cqrs/projection_message.go
@@ -722,8 +722,8 @@ func CanSyncEmbedMessage(behalfParticipantId int64, messageOwnerId int64, hasEmb
 	return messageOwnerId == behalfParticipantId && hasEmbed && canWriteMessage
 }
 
-func CanDeleteMessage(behalfParticipantId int64, messageOwnerId int64, canWriteMessage bool) bool {
-	return messageOwnerId == behalfParticipantId && canWriteMessage
+func CanDeleteMessage(behalfParticipantId int64, messageOwnerId int64, canWriteMessage bool, chatadmin bool, admincandelete bool) bool {
+	return (messageOwnerId == behalfParticipantId && canWriteMessage) || (chatadmin && admincandelete)
 }
 
 func CanPublishMessage(chatRegularParticipantCanPublishMessage, chatIsAdmin bool, messageOwnerId, behalfUserId int64) bool {

--- a/chat/db/migrations/000036_init.up.sql
+++ b/chat/db/migrations/000036_init.up.sql
@@ -1,0 +1,2 @@
+alter table chat_common 
+add column admin_can_delete_any_message boolean not null default false  

--- a/chat/dto/chat.go
+++ b/chat/dto/chat.go
@@ -4,16 +4,19 @@ import (
 	"time"
 )
 
-const NoChatTitle = ""
-const NoSearchString = ""
-const ReservedPublicallyAvailableForSearchChats = "__AVAILABLE_FOR_SEARCH"
-const DefaultCanReact = true
-const DefaultCanResend = false
-const DefaultAvailableToSearch = false
-const DefaultRegularParticipantCanWriteMessage = true
-const DefaultRegularParticipantCanPublishMessage = false
-const DefaultRegularParticipantCanPinMessage = false
-const DefaultRegularParticipantCanAddParticipant = true
+const (
+	NoChatTitle                                = ""
+	NoSearchString                             = ""
+	ReservedPublicallyAvailableForSearchChats  = "__AVAILABLE_FOR_SEARCH"
+	DefaultCanReact                            = true
+	DefaultCanResend                           = false
+	DefaultAvailableToSearch                   = false
+	DefaultRegularParticipantCanWriteMessage   = true
+	DefaultRegularParticipantCanPublishMessage = false
+	DefaultRegularParticipantCanPinMessage     = false
+	DefaultRegularParticipantCanAddParticipant = true
+	DefaultAdminCanDeleteAnyMessage            = false
+)
 
 type ChatViewDto struct {
 	Id                                  int64      `json:"id"`
@@ -42,6 +45,7 @@ type ChatViewDto struct {
 	AvailableToSearch                   bool       `json:"availableToSearch"`
 	IsParticipant                       bool       `json:"-"`
 	RegularParticipantCanAddParticipant bool       `json:"regularParticipantCanAddParticipant"`
+	AdminCanDeleteAnyMessage            bool       `json:"adminCanDeleteAnyMessage"`
 }
 
 type ChatId struct {
@@ -64,6 +68,7 @@ type ChatBaseCreateDto struct {
 	RegularParticipantCanPublishMessage *bool   `json:"regularParticipantCanPublishMessage"`
 	RegularParticipantCanPinMessage     *bool   `json:"regularParticipantCanPinMessage"`
 	RegularParticipantCanAddParticipant *bool   `json:"regularParticipantCanAddParticipant"`
+	AdminCanDeleteAnyMessage            *bool   `json:"adminCanDeleteAnyMessage"`
 }
 
 type ChatCreateDto struct {
@@ -120,6 +125,7 @@ type ChatBasic struct {
 	RegularParticipantCanPublishMessage bool    `db:"regular_participant_can_publish_message"`
 	RegularParticipantCanPinMessage     bool    `db:"regular_participant_can_pin_message"`
 	RegularParticipantCanWriteMessage   bool    `db:"regular_participant_can_write_message"`
+	AdminCanDeleteAnyMessage            bool    `db:"admin_can_delete_any_message"`
 }
 
 type BasicChatDtoExtended struct {
@@ -158,6 +164,7 @@ type ChatAuthorizationData struct {
 	AvailableToSearch                    bool `db:"chat_is_available_to_search"`
 	IsBlog                               bool `db:"chat_is_blog"`
 	RegularParticipantCanAddParticipants bool `db:"regular_participant_can_add_participant"`
+	AdminCanDeleteAnyMessage             bool `db:"admin_can_delete_any_message"`
 }
 
 type ChatNotificationSettingsChanged struct {

--- a/chat/dto/message.go
+++ b/chat/dto/message.go
@@ -311,19 +311,20 @@ type MessageReadResponse struct {
 }
 
 type MessageAuthorizationData struct {
-	IsParticipant         bool   `db:"is_chat_participant"`
-	IsChatAdmin           bool   `db:"is_chat_admin"`
-	IsBlog                bool   `db:"chat_is_blog"`
-	ChatIsTetATet         bool   `db:"chat_is_tet_a_tet"`
-	ChatCanWriteMessage   bool   `db:"chat_can_write_message"`
-	IsMessageFound        bool   `db:"is_message_found"`
-	IsChatFound           bool   `db:"is_chat_found"`
-	IsMessageBlogPost     bool   `db:"is_message_blog_post"`
-	MessageOwnerId        int64  `db:"message_owner_id"`
-	HasEmbedMessage       bool   `db:"message_has_embed"`
-	EmbedMessageTypeSafe  string `db:"message_embed_type"`
-	ChatCanPinMessage     bool   `db:"chat_can_pin_message"`
-	ChatCanPublishMessage bool   `db:"chat_can_publish_message"`
+	IsParticipant            bool   `db:"is_chat_participant"`
+	IsChatAdmin              bool   `db:"is_chat_admin"`
+	IsBlog                   bool   `db:"chat_is_blog"`
+	ChatIsTetATet            bool   `db:"chat_is_tet_a_tet"`
+	ChatCanWriteMessage      bool   `db:"chat_can_write_message"`
+	IsMessageFound           bool   `db:"is_message_found"`
+	IsChatFound              bool   `db:"is_chat_found"`
+	IsMessageBlogPost        bool   `db:"is_message_blog_post"`
+	MessageOwnerId           int64  `db:"message_owner_id"`
+	HasEmbedMessage          bool   `db:"message_has_embed"`
+	EmbedMessageTypeSafe     string `db:"message_embed_type"`
+	ChatCanPinMessage        bool   `db:"chat_can_pin_message"`
+	ChatCanPublishMessage    bool   `db:"chat_can_publish_message"`
+	AdminCanDeleteAnyMessage bool   `db:"admin_can_delete_any_message"`
 }
 
 type MessageAuthorizationDataBatch struct {

--- a/chat/handlers/chat.go
+++ b/chat/handlers/chat.go
@@ -88,6 +88,7 @@ func (ch *ChatHandler) CreateChat(g *gin.Context) {
 		RegularParticipantCanPinMessage:     utils.GetNullableBooleanOr(ccd.RegularParticipantCanPinMessage, dto.DefaultRegularParticipantCanPinMessage),
 		RegularParticipantCanWriteMessage:   utils.GetNullableBooleanOr(ccd.RegularParticipantCanWriteMessage, dto.DefaultRegularParticipantCanWriteMessage),
 		RegularParticipantCanAddParticipant: utils.GetNullableBooleanOr(ccd.RegularParticipantCanAddParticipant, dto.DefaultRegularParticipantCanAddParticipant),
+		AdminCanDeleteAnyMessage:            utils.GetNullableBooleanOr(ccd.AdminCanDeleteAnyMessage, dto.DefaultAdminCanDeleteAnyMessage),
 	}
 
 	chatId, err := cc.Handle(g.Request.Context(), ch.eventBus, ch.dbWrapper, ch.commonProjection, ch.stripTagsPolicy, ch.cfg, ch.rabbitmqOutputEventPublisher, ch.lgr)
@@ -188,6 +189,7 @@ func (ch *ChatHandler) EditChat(g *gin.Context) {
 		RegularParticipantCanPinMessage:     utils.GetNullableBooleanOr(ccd.RegularParticipantCanPinMessage, dto.DefaultRegularParticipantCanPinMessage),
 		RegularParticipantCanWriteMessage:   utils.GetNullableBooleanOr(ccd.RegularParticipantCanWriteMessage, dto.DefaultRegularParticipantCanWriteMessage),
 		RegularParticipantCanAddParticipant: utils.GetNullableBooleanOr(ccd.RegularParticipantCanAddParticipant, dto.DefaultRegularParticipantCanAddParticipant),
+		AdminCanDeleteAnyMessage:            utils.GetNullableBooleanOr(ccd.AdminCanDeleteAnyMessage, dto.DefaultAdminCanDeleteAnyMessage),
 	}
 
 	err = cc.Handle(g.Request.Context(), ch.eventBus, ch.dbWrapper, ch.commonProjection, ch.stripTagsPolicy, ch.cfg)

--- a/frontend/src/ChatEditModal.vue
+++ b/frontend/src/ChatEditModal.vue
@@ -141,6 +141,16 @@
                               color="primary"
                           ></v-checkbox>
 
+
+                          <v-checkbox
+                              :class="isMobile() ? 'mt-2': ''"
+                              v-model="editDto.adminCanDeleteAnyMessage"
+                              :label="$vuetify.locale.t('$vuetify.admin_can_delete_any_message')"
+                              hide-details
+                              density="compact"
+                              color="primary"
+                          ></v-checkbox>
+
                           <template v-if="!isNew">
                               <v-container class="pa-0 ma-0 mt-2">
                                   <img v-if="hasAva"
@@ -212,6 +222,7 @@
             regularParticipantCanWriteMessage: true,
             canReact: true,
             regularParticipantCanAddParticipant: true,
+            adminCanDeleteAnyMessage: true,
         }
     };
 
@@ -292,6 +303,7 @@
                 regularParticipantCanWriteMessage: chatDto.regularParticipantCanWriteMessage,
                 canReact: chatDto.canReact,
                 regularParticipantCanAddParticipant: chatDto.regularParticipantCanAddParticipant,
+                adminCanDeleteAnyMessage: chatDto.adminCanDeleteAnyMessage,
               }
             },
             loadCanCreateBlog() {

--- a/frontend/src/locale/en.js
+++ b/frontend/src/locale/en.js
@@ -369,5 +369,7 @@ export default {
     remove_contributing_to_unread: "Unread mute",
     start_contributing_to_unread: "Unread unmute",
     regular_participant_can_add_participant: "Regular participant can add participants",
-    add_participants: "Add participants"
+    add_participants: "Add participants",
+
+    admin_can_delete_any_message: "Admin can delete any message"
 }

--- a/frontend/src/locale/ru.js
+++ b/frontend/src/locale/ru.js
@@ -369,5 +369,8 @@ export default {
     remove_contributing_to_unread: "Непрочит. вкл",
     start_contributing_to_unread: "Непрочит. выкл",
     regular_participant_can_add_participant: "Участники могут добавлять участников",
-    add_participants: "Добавить участников"
+    add_participants: "Добавить участников",
+
+    admin_can_delete_any_message: "Администратор может удалить любое сообщение"
+
 }


### PR DESCRIPTION
adding an option when making a new chat to allow the admin to delete any message he want 
even if he is not the owner 

closes  #11